### PR TITLE
Handle datetime parsing exceptions in quest.py

### DIFF
--- a/nexus/quest.py
+++ b/nexus/quest.py
@@ -107,10 +107,16 @@ class Quest:
 
             quest_class = cls(**quest_dict)
 
-            quest_class.start_time = datetime.strptime(quest_dict['start_time'], "%Y-%m-%d %H:%M:%S.%f")
+            try:
+                quest_class.start_time = datetime.strptime(quest_dict['start_time'], "%Y-%m-%d %H:%M:%S.%f")
+            except ValueError:
+                quest_class.start_time = datetime.strptime(quest_dict['start_time'], "%Y-%m-%d %H:%M:%S")
 
             if quest_class.end_time:
-                quest_class.end_time = datetime.strptime(quest_dict['end_time'], "%Y-%m-%d %H:%M:%S.%f")
+                try:
+                    quest_class.end_time = datetime.strptime(quest_dict['end_time'], "%Y-%m-%d %H:%M:%S.%f")
+                except ValueError:
+                    quest_class.end_time = datetime.strptime(quest_dict['end_time'], "%Y-%m-%d %H:%M:%S")
 
             return quest_class
 


### PR DESCRIPTION
This commit adds exception handling for datetime parsing in quest.py to support both microsecond and second precision formats. It ensures that `start_time` and `end_time` are correctly parsed, improving the robustness of quest instantiation.